### PR TITLE
feat: switched authorization to authorization header

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -55,10 +55,12 @@ const doEverything = (fileText: string) => {
 	return base64String;
 };
 app.post("/", async (req: Request, res: Response) => {
-	const token = req.body.token;
-	const isTokenValid = await validateToken(token);
+	const authorizationHeader = req.header("Authorization");
+	const isTokenValid = await validateToken(authorizationHeader);
 	if (!isTokenValid) {
-		res.status(401).send(`Invalid token ${token} provided.`);
+		res.status(401).send(
+			`Invalid authorization header ${authorizationHeader} provided.`
+		);
 		return;
 	}
 	const fileString = req.body.string;

--- a/src/utility/authentication/functions.ts
+++ b/src/utility/authentication/functions.ts
@@ -1,6 +1,20 @@
-export const validateToken = async (token: string) => {
-	if (token !== process.env.ACCEPTED_AUTH_KEY) {
+export const validateToken = async (header: string | undefined) => {
+	// should be in the format "Bearer <token>"
+	const token = getTokenFromAuthorizationHeader(header);
+	if (token && token !== process.env.ACCEPTED_AUTH_KEY) {
 		return false;
 	}
 	return true;
+};
+
+export const getTokenFromAuthorizationHeader = (header: string | undefined) => {
+	if (!header || typeof header !== "string") {
+		return undefined;
+	}
+	const bearerRegex = /bearer (.+)$/i;
+	const match = header.match(bearerRegex);
+	if (!match || match.length <= 1) {
+		return undefined;
+	}
+	return match[1];
 };


### PR DESCRIPTION
The authorization is now provided by using the Authorization header in the format "Bearer <token>".

Closes #11