### PR TITLE
feat: endpoint now handles strings and zip files

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,59 +1,17 @@
 import express, { Express, Request, Response } from "express";
-import { v4 as uuidv4 } from "uuid";
-const cors = require("cors");
-const { spawnSync } = require("child_process");
-const fs = require("fs");
+//@ts-expect-error
+import cors from "cors";
 import "dotenv/config";
 
 import { validateToken } from "./src/utility/authentication/functions";
+import { handleRequest } from "./src/handlers";
 
-const baseDir = "./tmp";
 const app: Express = express();
 const port = 3000;
 
-app.use(express.json());
+app.use(express.json({ limit: "50mb" }));
 app.use(cors());
 
-const doEverything = (fileText: string) => {
-	if (!fileText) {
-		return;
-	}
-	const uniqueRequestId = uuidv4();
-
-	const requestDir = `${baseDir}/${uniqueRequestId}`;
-	const mainFile = `${requestDir}/main.tex`;
-	fs.mkdirSync(requestDir, { recursive: true });
-	fs.writeFileSync(mainFile, fileText);
-
-	const clean = spawnSync("latexmk", ["-C"]);
-	const process = spawnSync("latexmk", [
-		mainFile,
-		"-pdf",
-		"--shell-escape",
-		`-output-directory=${requestDir}`,
-	]);
-
-	// read the file in
-	const fileData = fs.readFileSync(`${requestDir}/main.pdf`);
-	console.log(`got pdf data`, fileData);
-	let base64String;
-	try {
-		base64String = fileData.toString("base64");
-		console.log("success");
-	} catch (e) {
-		console.error("Error getting the pdf file contents");
-		console.error(e);
-		throw e;
-	}
-
-	// delete the file that you just created
-	fs.rmSync(requestDir, {
-		recursive: true,
-		force: true,
-	});
-
-	return base64String;
-};
 app.post("/", async (req: Request, res: Response) => {
 	const authorizationHeader = req.header("Authorization");
 	const isTokenValid = await validateToken(authorizationHeader);
@@ -63,11 +21,12 @@ app.post("/", async (req: Request, res: Response) => {
 		);
 		return;
 	}
-	const fileString = req.body.string;
-	console.log("body:", req.body);
-	// console.log("body", req);
-	const data = doEverything(fileString);
-	// console.log("data:", data);
+	if (!req.body.string && !req.body.zip) {
+		res.status(400).send(
+			"Unable to find a valid 'zip' or 'string' attribute in request body"
+		);
+	}
+	const data = handleRequest(req, res);
 	res.status(200).send(data);
 });
 

--- a/src/handlers/handlers.ts
+++ b/src/handlers/handlers.ts
@@ -1,0 +1,103 @@
+import { Request, Response } from "express";
+import { spawnSync } from "child_process";
+import fs from "fs";
+import { v4 as uuidv4 } from "uuid";
+
+const BASE_DIR = "./tmp";
+
+export const handleRequest = (req: Request, res: Response) => {
+	console.log(`Beginning request processing`);
+	const workDir = setupProject();
+
+	let pdfData;
+	try {
+		if (req.body?.string) {
+			pdfData = handleStringRequest(workDir, req.body?.string);
+		} else if (req.body?.zip) {
+			pdfData = handleZipRequest(workDir, req.body?.zip);
+		}
+	} finally {
+		// delete the file that you just created
+		fs.rmSync(workDir, {
+			recursive: true,
+			force: true,
+		});
+	}
+
+	console.log(`Done with request`);
+	return pdfData;
+};
+
+const setupProject = () => {
+	const uniqueRequestId = uuidv4();
+	const requestDir = `${BASE_DIR}/${uniqueRequestId}`;
+	fs.mkdirSync(requestDir, { recursive: true });
+	console.log(`Done creating working directory in ${uniqueRequestId}`);
+	return requestDir;
+};
+
+export const handleStringRequest = (workDir: string, fileString: string) => {
+	if (!fileString) {
+		return;
+	}
+
+	const mainFile = `${workDir}/main.tex`;
+	fs.writeFileSync(mainFile, fileString);
+
+	const process = spawnSync("latexmk", [
+		mainFile,
+		"-pdf",
+		"--shell-escape",
+		`-output-directory=${workDir}`,
+	]);
+
+	// read the file in
+	const fileData = fs.readFileSync(`${workDir}/main.pdf`);
+	let base64String;
+	try {
+		base64String = fileData.toString("base64");
+	} catch (e) {
+		console.error("Error getting the pdf file contents");
+		console.error(e);
+		throw e;
+	}
+	return base64String;
+};
+
+export const handleZipRequest = (workDir: string, zipFileData: string) => {
+	if (!zipFileData) {
+		return;
+	}
+
+	// unpack the zipfile
+	const zipFile = `${workDir}/main.zip`;
+	const zipBinary = Buffer.from(zipFileData, "base64");
+	fs.writeFileSync(zipFile, zipBinary);
+	const unzip = spawnSync(`unzip`, [zipFile, "-d", workDir]);
+
+	const mainFile = `${workDir}/main.tex`;
+	if (!fs.existsSync(mainFile)) {
+		throw new Error(
+			"Provided zip file does not have a main.tex; aborting."
+		);
+	}
+
+	const process = spawnSync("latexmk", [
+		mainFile,
+		"-pdf",
+		"--shell-escape",
+		`-output-directory=${workDir}`,
+	]);
+
+	// read the file in
+	const fileData = fs.readFileSync(`${workDir}/main.pdf`);
+	let base64String;
+	try {
+		base64String = fileData.toString("base64");
+	} catch (e) {
+		console.error("Error getting the pdf file contents");
+		console.error(e);
+		throw e;
+	}
+	return base64String;
+};

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,0 +1,1 @@
+export { handleRequest } from "./handlers";


### PR DESCRIPTION
You can now send a raw string (via the 'string' attribute on the body) or send a zip file (via the 'zip' attribute.

Closes #4